### PR TITLE
Add database name to reader

### DIFF
--- a/app/App/Cli/Options.hs
+++ b/app/App/Cli/Options.hs
@@ -10,6 +10,7 @@ import           Data.ByteString     (ByteString)
 
 import qualified Amazonka.Data       as AWS
 import qualified App.Cli.Types       as CLI
+import           Data.RdsData.Aws
 import qualified Data.Text           as T
 import qualified Options.Applicative as OA
 
@@ -35,9 +36,9 @@ pCmds =
         $ OA.progDesc "Launch a local-stack RDS cluster."
     ]
 
-pUpCmd :: OA.Parser CLI.UpCmd
-pUpCmd =
-  CLI.UpCmd
+pStatementContext :: OA.Parser StatementContext
+pStatementContext =
+  StatementContext
     <$> do  OA.strOption $ mconcat
               [ OA.long "resource-arn"
               , OA.help "Resource ARN"
@@ -48,6 +49,17 @@ pUpCmd =
               , OA.help "Secret ARN"
               , OA.metavar "ARN"
               ]
+    <*> do  optional
+              ( OA.strOption $ mconcat
+                [ OA.long "database"
+                , OA.help "Database"
+                , OA.metavar "DATABASE"
+                ]
+              )
+pUpCmd :: OA.Parser CLI.UpCmd
+pUpCmd =
+  CLI.UpCmd
+    <$> pStatementContext
     <*> do  OA.strOption $ mconcat
               [ OA.long "migration-file"
               , OA.help "Migration File"
@@ -57,16 +69,7 @@ pUpCmd =
 pDownCmd :: OA.Parser CLI.DownCmd
 pDownCmd =
   CLI.DownCmd
-    <$> do  OA.strOption $ mconcat
-              [ OA.long "resource-arn"
-              , OA.help "Resource ARN"
-              , OA.metavar "ARN"
-              ]
-    <*> do  OA.strOption $ mconcat
-              [ OA.long "secret-arn"
-              , OA.help "Secret ARN"
-              , OA.metavar "ARN"
-              ]
+    <$> pStatementContext
     <*> do  OA.strOption $ mconcat
               [ OA.long "migration-file"
               , OA.help "Migration File"

--- a/app/App/Cli/Run/Example.hs
+++ b/app/App/Cli/Run/Example.hs
@@ -74,8 +74,8 @@ runExampleCmd cmd = do
   let theAwsLogLevel   = cmd ^. the @"mAwsLogLevel"
   let theMHostEndpoint = cmd ^. the @"mHostEndpoint"
   let theRegion        = cmd ^. the @"region"
-  let theResourceArn   = cmd ^. the @"resourceArn"
-  let theSecretArn     = cmd ^. the @"secretArn"
+  let theResourceArn   = cmd ^. the @"statementContext" . the @"resourceArn" . the @1
+  let theSecretArn     = cmd ^. the @"statementContext" . the @"secretArn" . the @1
 
   envAws <-
     liftIO (IO.unsafeInterleaveIO (mkEnv theRegion (awsLogger theAwsLogLevel)))

--- a/app/App/Cli/Run/ExecuteStatement.hs
+++ b/app/App/Cli/Run/ExecuteStatement.hs
@@ -27,8 +27,8 @@ runExecuteStatementCmd cmd = do
   let theAwsLogLevel   = cmd ^. the @"mAwsLogLevel"
   let theMHostEndpoint = cmd ^. the @"mHostEndpoint"
   let theRegion        = cmd ^. the @"region"
-  let theResourceArn   = cmd ^. the @"resourceArn"
-  let theSecretArn     = cmd ^. the @"secretArn"
+  let theResourceArn   = cmd ^. the @"statementContext" . the @"resourceArn" . the @1
+  let theSecretArn     = cmd ^. the @"statementContext" . the @"secretArn" . the @1
   let theSql           = cmd ^. the @"sql"
 
   envAws <-

--- a/app/App/Cli/Run/LocalStack.hs
+++ b/app/App/Cli/Run/LocalStack.hs
@@ -26,6 +26,7 @@ import qualified Control.Monad.Trans.Resource                      as IO
 import qualified Control.Monad.Trans.Resource.Internal             as IO
 import           Data.Acquire                                      (ReleaseType (ReleaseNormal))
 import           Data.Generics.Product.Any
+import           Data.RdsData.Aws
 import           Data.RdsData.Polysemy.Test.Cluster
 import           Data.RdsData.Polysemy.Test.Env
 import           GHC.IORef                                         (IORef)
@@ -113,15 +114,14 @@ runLocalStackCmd _ = do
       void $ runLocalTestEnv (pure container) do
         rdsClusterDetails <- createRdsDbCluster "rds_data_migration" (pure container)
 
-        runReaderResourceAndSecretArnsFromResponses rdsClusterDetails do
+        runReaderStatementContextFromResponses rdsClusterDetails do
           lsEp <- getLocalStackEndpoint container
           jotShow_ lsEp -- Localstack endpoint
           let port = lsEp ^. the @"port"
           let exampleCmd = "awslocal --endpoint-url=http://localhost:" <> show port <> " s3 ls"
           -- Example awslocal command:
           jot_ exampleCmd
-          jotShowM_ $ ask @AwsResourceArn
-          jotShowM_ $ ask @AwsSecretArn
+          jotShowM_ $ ask @StatementContext
           pure ()
 
       failure -- Not a failure

--- a/app/App/Cli/Run/Up.hs
+++ b/app/App/Cli/Run/Up.hs
@@ -36,8 +36,7 @@ newtype AppError
 runApp :: ()
   => CLI.UpCmd
   -> Sem
-      [ Reader AwsResourceArn
-      , Reader AwsSecretArn
+      [ Reader StatementContext
       , Reader AWS.Env
       , Error AppError
       , DataLog AwsLogEntry
@@ -50,8 +49,7 @@ runApp :: ()
       ] ()
   -> IO ()
 runApp cmd f = f
-  & runReader (AwsResourceArn $ cmd ^. the @"resourceArn")
-  & runReader (AwsSecretArn $ cmd ^. the @"secretArn")
+  & runReader (cmd ^. the @"statementContext")
   & runReaderAwsEnvDiscover
   & trap @AppError reportFatal
   & interpretDataLogAwsLogEntryToLog

--- a/app/App/Cli/Types.hs
+++ b/app/App/Cli/Types.hs
@@ -20,6 +20,7 @@ import           GHC.Generics
 
 import qualified Amazonka           as AWS
 import qualified Amazonka.RDSData   as AWS
+import           Data.RdsData.Aws
 
 data Cmd =
     CmdOfBatchExecuteStatementCmd BatchExecuteStatementCmd
@@ -30,42 +31,37 @@ data Cmd =
   | CmdOfUpCmd UpCmd
 
 data ExecuteStatementCmd = ExecuteStatementCmd
-  { mAwsLogLevel  :: Maybe AWS.LogLevel
-  , region        :: AWS.Region
-  , mHostEndpoint :: Maybe (ByteString, Int, Bool)
-  , resourceArn   :: Text
-  , secretArn     :: Text
-  , sql           :: Text
+  { mAwsLogLevel     :: Maybe AWS.LogLevel
+  , region           :: AWS.Region
+  , mHostEndpoint    :: Maybe (ByteString, Int, Bool)
+  , statementContext :: StatementContext
+  , sql              :: Text
   } deriving Generic
 
 data BatchExecuteStatementCmd = BatchExecuteStatementCmd
-  { mAwsLogLevel  :: Maybe AWS.LogLevel
-  , region        :: AWS.Region
-  , mHostEndpoint :: Maybe (ByteString, Int, Bool)
-  , parameterSets :: Maybe [[AWS.SqlParameter]]
-  , resourceArn   :: Text
-  , secretArn     :: Text
-  , sql           :: Text
+  { mAwsLogLevel     :: Maybe AWS.LogLevel
+  , region           :: AWS.Region
+  , mHostEndpoint    :: Maybe (ByteString, Int, Bool)
+  , parameterSets    :: Maybe [[AWS.SqlParameter]]
+  , statementContext :: StatementContext
+  , sql              :: Text
   } deriving Generic
 
 data ExampleCmd = ExampleCmd
-  { mAwsLogLevel  :: Maybe AWS.LogLevel
-  , region        :: AWS.Region
-  , mHostEndpoint :: Maybe (ByteString, Int, Bool)
-  , resourceArn   :: Text
-  , secretArn     :: Text
+  { mAwsLogLevel     :: Maybe AWS.LogLevel
+  , region           :: AWS.Region
+  , mHostEndpoint    :: Maybe (ByteString, Int, Bool)
+  , statementContext :: StatementContext
   } deriving Generic
 
 data UpCmd = UpCmd
-  { resourceArn :: Text
-  , secretArn   :: Text
-  , migrationFp :: FilePath
+  { statementContext :: StatementContext
+  , migrationFp      :: FilePath
   } deriving Generic
 
 data DownCmd = DownCmd
-  { resourceArn :: Text
-  , secretArn   :: Text
-  , migrationFp :: FilePath
+  { statementContext :: StatementContext
+  , migrationFp      :: FilePath
   } deriving Generic
 
 data LocalStackCmd = LocalStackCmd

--- a/integration/Test/Data/RdsData/Migration/ConnectionSpec.hs
+++ b/integration/Test/Data/RdsData/Migration/ConnectionSpec.hs
@@ -44,7 +44,7 @@ tasty_rds_integration_test =
       dbClusterArn <- rdsClusterDetails ^. the @"createDbClusterResponse" . the @"dbCluster" . _Just . the @"dbClusterArn"
         & nothingFail
 
-      runReaderResourceAndSecretArnsFromResponses rdsClusterDetails $ do
+      runReaderStatementContextFromResponses rdsClusterDetails $ do
         waitUntilRdsDbClusterAvailable dbClusterArn
           & trapFail @AWS.Error
           & jotShowDataLog @AwsLogEntry

--- a/src/Data/RdsData/Aws.hs
+++ b/src/Data/RdsData/Aws.hs
@@ -1,12 +1,33 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Data.RdsData.Aws
-  ( AwsResourceArn(..),
-    AwsSecretArn(..),
+  ( AwsResourceArn(AwsResourceArn),
+    AwsSecretArn(AwsSecretArn),
+    Database(Database),
+    StatementContext(StatementContext),
+    newStatementContext,
   ) where
 
-import           Data.Text (Text)
+import           Data.String  (IsString)
+import           Data.Text    (Text)
+import           GHC.Generics
 
 newtype AwsResourceArn = AwsResourceArn Text
-  deriving (Eq, Show)
+  deriving (Eq, Generic, IsString, Show)
 
 newtype AwsSecretArn = AwsSecretArn Text
-  deriving (Eq, Show)
+  deriving (Eq, Generic, IsString, Show)
+
+newtype Database = Database Text
+  deriving (Eq, Generic, IsString, Show)
+
+data StatementContext = StatementContext
+  { resourceArn :: AwsResourceArn
+  , secretArn   :: AwsSecretArn
+  , database    :: Maybe Database
+  } deriving (Eq, Generic, Show)
+
+newStatementContext :: AwsResourceArn -> AwsSecretArn -> StatementContext
+newStatementContext theResourceArn theSecretArn =
+  StatementContext theResourceArn theSecretArn Nothing


### PR DESCRIPTION
We now have `Reader StatementContext` instead of `Reader AwsResourceArn` and `Reader AwsSecretArn`.  The statement context contains both ARNs and an additional optional database name.

Migrations now can take additional `--database` CLI option:

```
AWS_PROFILE=only-on-chain cabal exec -- rds-data up --resource-arn "$AURORA_RESOURCE_ARN" --secret-arn "$AURORA_SECRET_ARN" --database only_on_chain --migration-file db/select.yaml
```