### PR TITLE
Add support for create_table and create_index steps

### DIFF
--- a/db/migration.yaml
+++ b/db/migration.yaml
@@ -2,49 +2,49 @@ description: This file contains the migration steps for the database schema.
 plan:
   - id: 01J6EWQ9NQRBQA3GT3FTCSRPJN
     description: Create Users table
-    up:
-      - | # sql
-        CREATE TABLE users (name VARCHAR(50));
+    steps:
+      - create_table:
+          name: users
+          columns:
+            - name: name
+              type: VARCHAR(50)
 
-      - | # sql
-        CREATE INDEX idx_users_name ON users (name);
-
-    down:
-      - | # sql
-        DROP INDEX idx_users_name;
-
-      - | # sql
-        DROP TABLE users;
+      - create_index:
+          name: idx_users_name
+          table: users
+          columns:
+            - name
 
   - id: 01J6EWQ9NQRBQA3GT3FTCSRPJN
     description: Create Projects table
-    up:
-      - | # sql
-        CREATE TABLE projects (name VARCHAR(50));
+    steps:
+      - up: | # sql
+          CREATE TABLE projects (name VARCHAR(50));
 
-      - | # sql
-        CREATE INDEX idx_projects_name ON projects (name);
+      - down: | # sql
+          DROP TABLE projects;
 
-    down:
-      - | # sql
-        DROP INDEX idx_projects_name;
+      - up: | # sql
+          CREATE INDEX idx_projects_name ON projects (name);
 
-      - | # sql
-        DROP TABLE projects;
+      - down: | # sql
+          DROP INDEX idx_projects_name;
 
   - id: 01J6PQ201YECE9R5XYTVWCRJC1
     description: Populate users table
-    up:
-      - | # sql
-        INSERT INTO users (name) VALUES ('Alice');
+    steps:
+      - up: | # sql
+          INSERT INTO users (name) VALUES ('Alice');
 
-      - | # sql
-        SELECT COUNT(name) FROM users;
+      - up: | # sql
+          SELECT COUNT(name) FROM users;
 
-      - | # sql
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = 'public'
-          AND table_type = 'BASE TABLE';
+      - up: | # sql
+          SELECT table_name
+          FROM information_schema.tables
+          WHERE table_schema = 'public'
+            AND table_type = 'BASE TABLE';
 
-    down: []
+      - up: | # sql
+          SELECT schema_name
+          FROM information_schema.schemata;

--- a/integration/Test/Data/RdsData/Migration/ConnectionSpec.hs
+++ b/integration/Test/Data/RdsData/Migration/ConnectionSpec.hs
@@ -78,6 +78,21 @@ tasty_rds_integration_test =
 
         L.sort upTables === ["migration", "projects", "users"]
 
+        -- upIndexResult <-
+        --   ( executeStatement $ mconcat
+        --       [ "SELECT schemaname, indexname, tablename"
+        --       , "  FROM pg_indexes"
+        --       , "  ORDER BY schemaname, tablename, indexname;"
+        --       ]
+        --   )
+        --   & trapFail @AWS.Error
+        --   & trapFail @RdsDataError
+        --   & jotShowDataLog
+
+        -- let upIndexes = upIndexResult ^.. the @"records" . each . each . each . the @"stringValue" . _Just
+
+        -- L.sort upIndexes === []
+
         migrateDown "db/migration.yaml"
           & trapFail @AWS.Error
           & trapFail @IOException

--- a/src/Data/RdsData/Migration/Types.hs
+++ b/src/Data/RdsData/Migration/Types.hs
@@ -1,26 +1,56 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DuplicateRecordFields      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
-{- HLINT ignore "Use let" -}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeApplications           #-}
 
 module Data.RdsData.Migration.Types
   ( MigrationRow(..),
     RdsClusterDetails(..),
     Migration(..),
+    Delta(..),
     Step(..),
     Statement(..),
+    CreateTableStep(..),
+    TableSchema(..),
+    Column(..),
+    ForeignKey(..),
   ) where
 
-import           Amazonka.Data           (FromJSON, ToJSON)
-import qualified Amazonka.RDS            as AWS
-import qualified Amazonka.SecretsManager as AWS
-import           Data.RdsData.Orphans    ()
-import           Data.Text               (Text)
+import           Amazonka.Data             (FromJSON, ToJSON, (.!=), (.:),
+                                            (.:?), (.=))
+import qualified Amazonka.RDS              as AWS
+import qualified Amazonka.SecretsManager   as AWS
+import           Control.Applicative
+import qualified Data.Aeson                as J
+import           Data.Bool
+import           Data.Char                 (isAsciiUpper, toLower)
+import           Data.Generics.Product.Any
+import           Data.Maybe
+import           Data.RdsData.Orphans      ()
+import           Data.Text                 (Text)
 import           Data.Time
-import           Data.ULID               (ULID)
+import           Data.ULID                 (ULID)
 import           GHC.Generics
+import           Lens.Micro
+
+-- Helper to transform field names to snake_case
+snakeCaseOptions :: J.Options
+snakeCaseOptions = J.defaultOptions { J.fieldLabelModifier = camelToSnake }
+
+-- Helper function to convert camelCase to snake_case
+camelToSnake :: String -> String
+camelToSnake [] = []
+camelToSnake (x:xs) = toLower x : go xs
+  where
+    go [] = []
+    go "_" = []
+    go (y:ys)
+      | isAsciiUpper y = '_' : toLower y : go ys
+      | otherwise      = y : go ys
 
 data MigrationRow = MigrationRow
   { uuid       :: ULID
@@ -35,26 +65,158 @@ data RdsClusterDetails = RdsClusterDetails
 
 data Migration = Migration
   { description :: Text
-  , plan        :: [Step]
-  }
-  deriving (Eq, Generic, Show)
+  , plan        :: [Delta]
+  } deriving (Eq, Generic, Show)
 
-instance ToJSON Migration
+instance ToJSON Migration where
+  toJSON = J.genericToJSON snakeCaseOptions
 
-instance FromJSON Migration
+instance FromJSON Migration where
+  parseJSON = J.genericParseJSON snakeCaseOptions
 
-data Step = Step
+data Delta = Delta
   { id          :: ULID
   , description :: Text
-  , up          :: [Statement]
-  , down        :: [Statement]
-  }
-  deriving (Eq, Generic, Show)
+  , steps       :: Maybe [Step]
+  } deriving (Eq, Generic, Show)
 
-instance ToJSON Step
+instance ToJSON Delta where
+  toJSON = J.genericToJSON snakeCaseOptions
 
-instance FromJSON Step
+instance FromJSON Delta where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+data Step =
+    StepOfUp UpStep
+  | StepOfDown DownStep
+  | StepOfCreateTable CreateTableStep
+  | StepOfCreateIndex CreateIndexStep
+  deriving (Eq, Show)
+
+instance ToJSON Step where
+  toJSON = \case
+    StepOfUp step -> J.toJSON step
+    StepOfDown step -> J.toJSON step
+    StepOfCreateTable table -> J.toJSON table
+    StepOfCreateIndex index -> J.toJSON index
+
+instance FromJSON Step where
+  parseJSON v =
+    flip (J.withObject "Step") v $ \_ ->
+      asum
+        [ StepOfUp          <$> J.parseJSON v
+        , StepOfDown        <$> J.parseJSON v
+        , StepOfCreateTable <$> J.parseJSON v
+        , StepOfCreateIndex <$> J.parseJSON v
+        ]
+
+newtype UpStep = UpStep
+  { up   :: Statement
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON UpStep where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON UpStep where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+newtype DownStep = DownStep
+  { down :: Statement
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON DownStep where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON DownStep where
+  parseJSON = J.genericParseJSON snakeCaseOptions
 
 newtype Statement = Statement Text
   deriving (Eq, Generic, Show)
   deriving newtype (ToJSON, FromJSON)
+
+newtype CreateTableStep = CreateTableStep
+  { createTable :: TableSchema
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON CreateTableStep where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON CreateTableStep where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+newtype CreateIndexStep = CreateIndexStep
+  { createIndex :: IndexSchema
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON CreateIndexStep where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON CreateIndexStep where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+data TableSchema = TableSchema
+  { name    :: Text
+  , columns :: [Column]
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON TableSchema where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON TableSchema where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+data Column = Column
+  { name          :: Text
+  , type_         :: Text
+  , nullable      :: Bool
+  , primaryKey    :: Bool
+  , unique        :: Bool
+  , autoIncrement :: Bool
+  , references    :: Maybe ForeignKey
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON Column where
+  toJSON column =
+    J.object $ catMaybes
+      [ "name"            .=? do column ^. the @"name"          & Just
+      , "type"            .=? do column ^. the @"type_"         & Just
+      , "nullable"        .=? do column ^. the @"nullable"      & bool Nothing (Just True)
+      , "primary_key"     .=? do column ^. the @"primaryKey"    & bool Nothing (Just True)
+      , "unique"          .=? do column ^. the @"unique"        & bool Nothing (Just True)
+      , "auto_increment"  .=? do column ^. the @"autoIncrement" & bool Nothing (Just True)
+      , "references"      .=? do column ^. the @"references"    & Just
+      ]
+
+(.=?) :: (J.KeyValue e kv, ToJSON v) => J.Key -> Maybe v -> Maybe kv
+(.=?) k mv =
+  case mv of
+    Just v  -> Just $ k .= v
+    Nothing -> Nothing
+
+instance FromJSON Column where
+  parseJSON = J.withObject "Column" $ \v ->
+    Column
+      <$> v .:  "name"
+      <*> v .:  "type"
+      <*> v .:? "nullable"        .!= False
+      <*> v .:? "primary_key"     .!= False
+      <*> v .:? "unique"          .!= False
+      <*> v .:? "auto_increment"  .!= False
+      <*> v .:? "references"
+
+data IndexSchema = IndexSchema
+  { name    :: Text
+  , table   :: Text
+  , columns :: [Text]
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON IndexSchema where
+  toJSON = J.genericToJSON snakeCaseOptions
+
+instance FromJSON IndexSchema where
+  parseJSON = J.genericParseJSON snakeCaseOptions
+
+
+newtype ForeignKey = ForeignKey Text
+  deriving newtype (Eq, Show, ToJSON, FromJSON)
+  deriving Generic


### PR DESCRIPTION
You can use the new `create_table` and `create_index` steps to have a more descriptive way to create tables and indexes.

Alternatively you could fallback to using the `up` and `down` steps.

```
description: This file contains the migration steps for the database schema.
plan:
  - id: 01J6EWQ9NQRBQA3GT3FTCSRPJN
    description: Create Users table
    steps:
      - create_table:
          name: users
          columns:
            - name: name
              type: VARCHAR(50)

      - create_index:
          name: idx_users_name
          table: users
          columns:
            - name

  - id: 01J6EWQ9NQRBQA3GT3FTCSRPJN
    description: Create Projects table
    steps:
      - up: | # sql
          CREATE TABLE projects (name VARCHAR(50));

      - down: | # sql
          DROP TABLE projects;

      - up: | # sql
          CREATE INDEX idx_projects_name ON projects (name);

      - down: | # sql
          DROP INDEX public.idx_projects_name;
```